### PR TITLE
Add initial Go REST API scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# test-codex-app
+# Test Codex App
+
+This is a simple REST API written in Go. It demonstrates a layered architecture with routes, controllers, services and clients.
+
+## Running
+
+```
+go run ./...
+```
+
+The server listens on `:8080` and exposes the following endpoints:
+
+- `POST /users` – create a new user
+- `GET /users` – list all users
+- `GET /users/{id}` – retrieve a user by ID
+- `PUT /users/{id}` – update a user
+- `DELETE /users/{id}` – delete a user
+
+Data is stored in memory via an in-memory cache client.
+

--- a/clients/user_client.go
+++ b/clients/user_client.go
@@ -1,0 +1,76 @@
+package clients
+
+import (
+	"errors"
+	"sync"
+
+	"testcodex/models"
+)
+
+// UserClient simulates a user database client using an in-memory map.
+type UserClient struct {
+	mu     sync.Mutex
+	users  map[int]*models.User
+	nextID int
+}
+
+// NewUserClient creates a new in-memory user client.
+func NewUserClient() *UserClient {
+	return &UserClient{users: make(map[int]*models.User), nextID: 1}
+}
+
+// Create stores a new user and returns it.
+func (c *UserClient) Create(u *models.User) *models.User {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	u.ID = c.nextID
+	c.nextID++
+	c.users[u.ID] = u
+	return u
+}
+
+// Get retrieves a user by ID.
+func (c *UserClient) Get(id int) (*models.User, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	u, ok := c.users[id]
+	if !ok {
+		return nil, errors.New("user not found")
+	}
+	return u, nil
+}
+
+// Update modifies an existing user.
+func (c *UserClient) Update(id int, u *models.User) (*models.User, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.users[id]
+	if !ok {
+		return nil, errors.New("user not found")
+	}
+	u.ID = id
+	c.users[id] = u
+	return u, nil
+}
+
+// Delete removes a user by ID.
+func (c *UserClient) Delete(id int) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.users[id]; !ok {
+		return errors.New("user not found")
+	}
+	delete(c.users, id)
+	return nil
+}
+
+// List returns all stored users.
+func (c *UserClient) List() []*models.User {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	users := make([]*models.User, 0, len(c.users))
+	for _, u := range c.users {
+		users = append(users, u)
+	}
+	return users
+}

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -1,0 +1,106 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"testcodex/models"
+	"testcodex/services"
+)
+
+// UserController handles HTTP requests for users.
+type UserController struct {
+	service *services.UserService
+}
+
+// NewUserController creates a new controller.
+func NewUserController(s *services.UserService) *UserController {
+	return &UserController{service: s}
+}
+
+// HandleUsers handles "/users" route for GET and POST.
+func (uc *UserController) HandleUsers(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		uc.listUsers(w, r)
+	case http.MethodPost:
+		uc.createUser(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// HandleUserByID handles "/users/{id}" routes.
+func (uc *UserController) HandleUserByID(w http.ResponseWriter, r *http.Request) {
+	idStr := strings.TrimPrefix(r.URL.Path, "/users/")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		uc.getUser(w, r, id)
+	case http.MethodPut:
+		uc.updateUser(w, r, id)
+	case http.MethodDelete:
+		uc.deleteUser(w, r, id)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (uc *UserController) createUser(w http.ResponseWriter, r *http.Request) {
+	var u models.User
+	if err := json.NewDecoder(r.Body).Decode(&u); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	created := uc.service.Create(&u)
+	respondJSON(w, http.StatusCreated, created)
+}
+
+func (uc *UserController) listUsers(w http.ResponseWriter, r *http.Request) {
+	users := uc.service.List()
+	respondJSON(w, http.StatusOK, users)
+}
+
+func (uc *UserController) getUser(w http.ResponseWriter, r *http.Request, id int) {
+	user, err := uc.service.Get(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	respondJSON(w, http.StatusOK, user)
+}
+
+func (uc *UserController) updateUser(w http.ResponseWriter, r *http.Request, id int) {
+	var u models.User
+	if err := json.NewDecoder(r.Body).Decode(&u); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	updated, err := uc.service.Update(id, &u)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	respondJSON(w, http.StatusOK, updated)
+}
+
+func (uc *UserController) deleteUser(w http.ResponseWriter, r *http.Request, id int) {
+	if err := uc.service.Delete(id); err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func respondJSON(w http.ResponseWriter, status int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(data)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module testcodex
+
+go 1.23.8

--- a/main.go
+++ b/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"testcodex/clients"
+	"testcodex/controllers"
+	"testcodex/routes"
+	"testcodex/services"
+)
+
+func main() {
+	client := clients.NewUserClient()
+	service := services.NewUserService(client)
+	controller := controllers.NewUserController(service)
+
+	router := routes.SetupRoutes(controller)
+
+	log.Println("Starting server on :8080")
+	if err := http.ListenAndServe(":8080", router); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/models/user.go
+++ b/models/user.go
@@ -1,0 +1,8 @@
+package models
+
+// User represents a simple user model.
+type User struct {
+	ID    int    `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -1,0 +1,15 @@
+package routes
+
+import (
+	"net/http"
+
+	"testcodex/controllers"
+)
+
+// SetupRoutes configures the HTTP routes.
+func SetupRoutes(controller *controllers.UserController) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users", controller.HandleUsers)
+	mux.HandleFunc("/users/", controller.HandleUserByID)
+	return mux
+}

--- a/services/user_service.go
+++ b/services/user_service.go
@@ -1,0 +1,36 @@
+package services
+
+import (
+	"testcodex/clients"
+	"testcodex/models"
+)
+
+// UserService provides user operations.
+type UserService struct {
+	client *clients.UserClient
+}
+
+// NewUserService creates a new user service.
+func NewUserService(c *clients.UserClient) *UserService {
+	return &UserService{client: c}
+}
+
+func (s *UserService) Create(u *models.User) *models.User {
+	return s.client.Create(u)
+}
+
+func (s *UserService) Get(id int) (*models.User, error) {
+	return s.client.Get(id)
+}
+
+func (s *UserService) Update(id int, u *models.User) (*models.User, error) {
+	return s.client.Update(id, u)
+}
+
+func (s *UserService) Delete(id int) error {
+	return s.client.Delete(id)
+}
+
+func (s *UserService) List() []*models.User {
+	return s.client.List()
+}


### PR DESCRIPTION
## Summary
- initialize Go module
- add user model and in-memory client
- create service and controller layers
- wire up routes and main server
- document usage in README

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c39e31e708324b5ddba343a76dbbe